### PR TITLE
cmd/export9p: split fs/real package for third parties

### DIFF
--- a/cmd/export9p/main.go
+++ b/cmd/export9p/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/knusbaum/go9p"
 	"github.com/knusbaum/go9p/fs"
+	"github.com/knusbaum/go9p/fs/real"
 )
 
 var exportFS fs.FS
@@ -36,10 +37,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	exportFS.Root = &RealDir{Path: dir}
-	fs.WithCreateFile(CreateRealFile)(&exportFS)
-	fs.WithCreateDir(CreateRealDir)(&exportFS)
-	fs.WithRemoveFile(RemoveReal)(&exportFS)
+	exportFS.Root = &real.Dir{Path: dir}
+	fs.WithCreateFile(real.CreateFile)(&exportFS)
+	fs.WithCreateDir(real.CreateDir)(&exportFS)
+	fs.WithRemoveFile(real.Remove)(&exportFS)
 	if *noperm {
 		fs.IgnorePermissions()(&exportFS)
 	}

--- a/fs/real/usergroup_nix.go
+++ b/fs/real/usergroup_nix.go
@@ -1,6 +1,6 @@
 // +build !plan9
 
-package main
+package real
 
 import (
 	"fmt"

--- a/fs/real/usergroup_plan9.go
+++ b/fs/real/usergroup_plan9.go
@@ -1,4 +1,4 @@
-package main
+package real
 
 import (
 	"fmt"


### PR DESCRIPTION
Split the `fs/real` package so that it can be imported by third party projects.
    
Also change `real.RealDir` -> `real.Dir` to avoid stutter.
https://blog.golang.org/package-names

- - -
No substantial code change.