### PR TITLE
Plan 9 union filesystem implementation

### DIFF
--- a/fs/server.go
+++ b/fs/server.go
@@ -195,6 +195,13 @@ func (s *server) Walk(gc go9p.Conn, t *proto.TWalk) (proto.FCall, error) {
 		}
 	}
 
+	if t.Nwname > 0 && t.Wname[0] == "." {
+		c.fids.Store(t.Newfid, info.deriveInfo(file))
+		qids := make([]proto.Qid, 1)
+		qids[0] = file.Stat().Qid
+		return &proto.RWalk{proto.Header{proto.Rwalk, t.Tag}, 1, qids}, nil
+	}
+
 	qids := make([]proto.Qid, 0)
 	for i := 0; i < int(t.Nwname); i++ {
 		if dir, ok := file.(Dir); ok {

--- a/union/union.go
+++ b/union/union.go
@@ -1,0 +1,738 @@
+package union
+
+import (
+	"fmt"
+	iofs "io/fs"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/knusbaum/go9p/client"
+	"github.com/knusbaum/go9p/fs"
+	"github.com/knusbaum/go9p/proto"
+)
+
+type MountOption int
+
+const (
+	REPLACE MountOption = iota
+	BEFORE
+	AFTER
+)
+
+type mountEntry struct {
+	c          *client.Client
+	f          *UnionFile
+	d          *UnionDir
+	mountPoint string
+	replace    bool
+	create     bool
+}
+
+type baseUnionNode struct {
+	sync.RWMutex
+	parent *UnionDir
+	path   string
+	mount  mountEntry
+}
+
+func (n *baseUnionNode) Parent() fs.Dir {
+	n.RLock()
+	defer n.RUnlock()
+	return n.parent
+}
+
+func (n *baseUnionNode) SetParent(p fs.Dir) {
+	n.Lock()
+	defer n.Unlock()
+
+	ud, ok := p.(*UnionDir)
+	if !ok {
+		panic(fmt.Errorf("parent must be set to a union directory"))
+	}
+	n.parent = ud
+}
+
+func (n *baseUnionNode) Stat() proto.Stat {
+	// This is the root
+	if n.path == "" {
+		// TODO make this stat as the root directory
+		return proto.Stat{
+			Mode: 0x80000000,
+		}
+	}
+
+	rel, err := filepath.Rel(n.mount.mountPoint, n.path)
+	if err != nil {
+		return proto.Stat{}
+	}
+
+	switch {
+	case n.mount.c != nil:
+		stat, err := n.mount.c.Stat(rel)
+		if err != nil {
+			return proto.Stat{}
+		}
+		return *stat
+	case n.mount.f != nil:
+		return n.mount.f.Stat()
+	case n.mount.d != nil:
+		return n.mount.d.Stat()
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+func (n *baseUnionNode) WriteStat(s *proto.Stat) error {
+	if n.mount.c == nil {
+		return fmt.Errorf("the root directory cannot be modified")
+	}
+
+	rel, err := filepath.Rel(n.mount.mountPoint, n.path)
+	if err != nil {
+		// TODO consider panic instead
+		return fmt.Errorf("this should never happen")
+	}
+
+	switch {
+	case n.mount.c != nil:
+		return n.mount.c.WStat(rel, s)
+	case n.mount.f != nil:
+		return n.mount.f.WriteStat(s)
+	case n.mount.d != nil:
+		on := n.mount.d.find(rel)
+		if on == nil {
+			return fmt.Errorf("stale mount")
+		}
+		return on.WriteStat(s)
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+type UnionDir struct {
+	baseUnionNode
+	mountTable []mountEntry
+}
+
+// Create a new union directory.
+//
+// Note that the caller must take a copy of the mount table
+// so that it can be owned by the new union directory.
+func NewUnionDir(n baseUnionNode, mountTable []mountEntry) *UnionDir {
+	return &UnionDir{
+		baseUnionNode: n,
+		mountTable:    mountTable,
+	}
+}
+
+func (ud *UnionDir) find(rel string) *baseUnionNode {
+	if strings.HasPrefix(rel, "/") {
+		rel = rel[1:]
+	}
+
+	if rel == "" {
+		return &ud.baseUnionNode
+	}
+
+	parts := strings.Split(rel, "/")
+	d := ud
+	var n *baseUnionNode
+
+	for _, part := range parts {
+		if d == nil {
+			return nil
+		}
+
+		children := d.Children()
+		child, ok := children[part]
+		if !ok {
+			return nil
+		}
+
+		n = child.(*baseUnionNode)
+		if cd, ok := child.(*UnionDir); ok {
+			d = cd
+		}
+	}
+
+	return n
+}
+
+func (ud *UnionDir) findDir(rel string) *UnionDir {
+	if strings.HasPrefix(rel, "/") {
+		rel = rel[1:]
+	}
+
+	if rel == "" {
+		return ud
+	}
+
+	parts := strings.Split(rel, "/")
+	d := ud
+	var n *UnionDir
+
+	for _, part := range parts {
+		if d == nil {
+			return nil
+		}
+
+		children := d.Children()
+		child, ok := children[part]
+		if !ok {
+			return nil
+		}
+
+		n, ok = child.(*UnionDir)
+		d = n
+		if !ok {
+			return nil
+		}
+	}
+
+	return n
+}
+
+func (ud *UnionDir) findFile(rel string) *UnionFile {
+	if strings.HasPrefix(rel, "/") {
+		rel = rel[1:]
+	}
+
+	if rel == "" {
+		return nil
+	}
+
+	parts := strings.Split(rel, "/")
+	d := ud
+	var n fs.FSNode
+
+	for _, part := range parts {
+		if d == nil {
+			return nil
+		}
+
+		children := d.Children()
+		child, ok := children[part]
+		if !ok {
+			return nil
+		}
+
+		n = child
+		if cd, ok := child.(*UnionDir); ok {
+			d = cd
+		}
+	}
+
+	if uf, ok := n.(*UnionFile); ok {
+		return uf
+	}
+
+	return nil
+}
+
+func (ud *UnionDir) RemoveFile(f fs.FSNode) error {
+	// TODO maybe someone will want to remove directories someday
+	uf, ok := f.(*UnionFile)
+	if !ok {
+		return fmt.Errorf("cannot remove file that is not a union filesystem file")
+	}
+
+	rel, err := filepath.Rel(ud.mount.mountPoint, uf.path)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case ud.mount.c != nil:
+		return ud.mount.c.Remove(rel)
+	case ud.mount.d != nil:
+		on := ud.mount.d.find(rel)
+		if on == nil {
+			return fmt.Errorf("stale mount")
+		}
+		if on.parent == nil {
+			return fmt.Errorf("cannot remove root")
+		}
+		return on.parent.RemoveFile(on)
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+func (ud *UnionDir) CreateFile(user, name string, perm uint32, mode uint8) (fs.File, error) {
+	// First, we find the mount that will permit creation
+	mte := ud.mount
+	if !mte.create {
+		for _, me := range ud.mountTable {
+			if me.create == true && ud.path == me.mountPoint {
+				mte = me
+				break
+			}
+		}
+	}
+
+	if !mte.create {
+		return nil, fmt.Errorf("creation is not permitted here")
+	}
+
+	rel, err := filepath.Rel(mte.mountPoint, filepath.Join(ud.path, name))
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case mte.c != nil:
+		// TODO how do we pass in the user here?
+		f, err := mte.c.Create(rel, iofs.FileMode((uint32(mode)<<24)|(perm&0x00FFFFFF)))
+		if err != nil {
+			return nil, err
+		}
+		// The file comes pre-opened on create using the client API
+		// so we close it for now.
+		f.Close()
+
+		n := baseUnionNode{
+			path:  filepath.Join(ud.path, name),
+			mount: mte,
+		}
+
+		return NewUnionFile(n), nil
+	case mte.d != nil:
+		on := mte.d.find(rel)
+		if on == nil {
+			return nil, fmt.Errorf("stale mount")
+		}
+		if on.parent == nil {
+			return nil, fmt.Errorf("cannot create root")
+		}
+		return on.parent.CreateFile(user, name, perm, mode)
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+func (ud *UnionDir) CreateDir(user, name string, perm uint32, mode uint8) (fs.Dir, error) {
+	// TODO check the mode to ensure that this is DMDIR
+
+	mte := ud.mount
+	if !mte.create {
+		for _, me := range ud.mountTable {
+			if me.create == true && ud.path == me.mountPoint {
+				mte = me
+				break
+			}
+		}
+	}
+
+	if !mte.create {
+		return nil, fmt.Errorf("creation is not permitted here")
+	}
+
+	rel, err := filepath.Rel(mte.mountPoint, filepath.Join(ud.path, name))
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case mte.c != nil:
+		// TODO how do we pass in the user here?
+		f, err := mte.c.Create(rel, iofs.FileMode((uint32(mode)<<24)|(perm&0x00FFFFFF)))
+		if err != nil {
+			return nil, err
+		}
+		// The file comes pre-opened on create using the client API
+		// so we close it for now.
+		f.Close()
+
+		n := baseUnionNode{
+			path:  filepath.Join(ud.path, name),
+			mount: mte,
+		}
+
+		// Lock to grab a copy of the mount table
+		ud.RLock()
+		mountTable := append([]mountEntry{}, ud.mountTable...)
+		ud.RUnlock()
+		return NewUnionDir(n, mountTable), nil
+	case mte.d != nil:
+		on := mte.d.find(rel)
+		if on == nil {
+			return nil, fmt.Errorf("stale mount")
+		}
+		if on.parent == nil {
+			return nil, fmt.Errorf("cannot create the root")
+		}
+		return on.parent.CreateDir(user, name, perm, mode)
+
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+func (ud *UnionDir) Children() map[string]fs.FSNode {
+	children := make(map[string]fs.FSNode)
+
+	// Lock to read the mount table to take a copy of it
+	ud.RLock()
+	mountTable := append([]mountEntry{}, ud.mountTable...)
+	ud.RUnlock()
+
+	// TODO consider a scatter/gather approach with goroutines since these can be I/O blocking
+	for _, me := range mountTable {
+		isCurrentMount := ud.mount.c == me.c && ud.mount.d == me.d && ud.mount.f == me.f
+
+		if ud.path != me.mountPoint && !isCurrentMount {
+			continue
+		}
+
+		rel, err := filepath.Rel(me.mountPoint, ud.path)
+		if err != nil {
+			continue
+		}
+
+		if rel == "." {
+			rel = "/"
+		}
+
+		switch {
+		case me.c != nil:
+			sts, err := me.c.Readdir(rel)
+			// TODO should we expire this mount somehow?
+			if err != nil {
+				continue
+			}
+
+			for _, stat := range sts {
+				n := baseUnionNode{
+					path:  filepath.Join(ud.path, stat.Name),
+					mount: me,
+				}
+
+				// TODO this constant should really be in the go9p package
+				if stat.Mode&0x80000000 != 0 {
+					children[stat.Name] = NewUnionDir(n, append([]mountEntry{}, mountTable...))
+				} else {
+					// TODO check if there is a mount point for the file here
+					children[stat.Name] = NewUnionFile(n)
+				}
+			}
+		case me.d != nil:
+			on := me.d.findDir(rel)
+			if on == nil {
+				continue
+			}
+			subchildren := on.Children()
+			for name, n := range subchildren {
+				if udn, ok := n.(*UnionDir); ok {
+					udn.mount = me
+					udn.path = filepath.Join(ud.path, name)
+					udn.mountTable = append([]mountEntry{}, mountTable...)
+					children[name] = udn
+				}
+				if ufn, ok := n.(*UnionFile); ok {
+					ufn.mount = me
+					ufn.path = filepath.Join(ud.path, name)
+					children[name] = ufn
+				}
+			}
+		}
+
+		if me.replace && !isCurrentMount {
+			return children
+		}
+	}
+
+	return children
+}
+
+type UnionFile struct {
+	baseUnionNode
+	opens   map[uint64]*client.File
+	openufs map[uint64]*UnionFile
+}
+
+func NewUnionFile(n baseUnionNode) *UnionFile {
+	return &UnionFile{
+		baseUnionNode: n,
+		opens:         make(map[uint64]*client.File),
+		openufs:       make(map[uint64]*UnionFile),
+	}
+}
+
+func (uf *UnionFile) Open(fid uint64, omode proto.Mode) error {
+	rel, err := filepath.Rel(uf.mount.mountPoint, uf.path)
+	if err != nil {
+		return err
+	}
+
+	uf.Lock()
+	defer uf.Unlock()
+
+	switch {
+	case uf.mount.c != nil:
+		f, err := uf.mount.c.Open(rel, omode)
+		if err != nil {
+			return err
+		}
+		uf.opens[fid] = f
+		return nil
+	case uf.mount.d != nil:
+		// Store the relative path for later when we're dealing with only fids
+		on := uf.mount.d.findFile(rel)
+		if on == nil {
+			return fmt.Errorf("stale mount")
+		}
+		uf.openufs[fid] = on
+		return on.Open(fid, omode)
+	case uf.mount.f != nil:
+		return uf.mount.f.Open(fid, omode)
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+func (uf *UnionFile) Read(fid uint64, offset uint64, count uint64) ([]byte, error) {
+	uf.RLock()
+	defer uf.RUnlock()
+
+	switch {
+	case uf.mount.c != nil:
+		file, ok := uf.opens[fid]
+		if !ok {
+			return []byte{}, fmt.Errorf("fid is not open: %d", fid)
+		}
+
+		buf := make([]byte, count)
+		// TODO how to make this type conversion to signed safe
+		n, err := file.ReadAt(buf, int64(offset))
+		return buf[:n], err
+	case uf.mount.d != nil:
+		on := uf.openufs[fid]
+		if on == nil {
+			return []byte{}, fmt.Errorf("unknown fid, or file closed")
+		}
+		return on.Read(fid, offset, count)
+	case uf.mount.f != nil:
+		return uf.mount.f.Read(fid, offset, count)
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+func (uf *UnionFile) Write(fid uint64, offset uint64, data []byte) (uint32, error) {
+	uf.RLock()
+	defer uf.RUnlock()
+
+	switch {
+	case uf.mount.c != nil:
+		file, ok := uf.opens[fid]
+		if !ok {
+			return 0, fmt.Errorf("fid is not open: %d", fid)
+		}
+
+		// TODO how to make this type conversion to signed safe
+		n, err := file.WriteAt(data, int64(offset))
+		return uint32(n), err
+	case uf.mount.d != nil:
+		on := uf.openufs[fid]
+		if on == nil {
+			return 0, fmt.Errorf("unknown fid, or file closed")
+		}
+		return on.Write(fid, offset, data)
+	case uf.mount.f != nil:
+		return uf.mount.f.Write(fid, offset, data)
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+func (uf *UnionFile) Close(fid uint64) error {
+	switch {
+	case uf.mount.c != nil:
+		file, ok := uf.opens[fid]
+		if !ok {
+			return fmt.Errorf("fid is not open: %d", fid)
+		}
+		delete(uf.opens, fid)
+		return file.Close()
+	case uf.mount.f != nil:
+		on := uf.openufs[fid]
+		if on == nil {
+			return fmt.Errorf("unknown fid, or file closed")
+		}
+		delete(uf.openufs, fid)
+		return on.Close(fid)
+	case uf.mount.f != nil:
+		return uf.mount.f.Close(fid)
+	}
+
+	panic(fmt.Errorf("invalid mount table state"))
+}
+
+func CreateUnionFile(fs *fs.FS, p fs.Dir, user, name string, perm uint32, mode uint8) (fs.File, error) {
+	parent, ok := p.(*UnionDir)
+	if !ok {
+		return nil, fmt.Errorf("directory is not a union filesystem directory")
+	}
+	return parent.CreateFile(user, name, perm, mode)
+}
+
+func CreateUnionDir(fs *fs.FS, p fs.Dir, user, name string, perm uint32, mode uint8) (fs.Dir, error) {
+	parent, ok := p.(*UnionDir)
+	if !ok {
+		return nil, fmt.Errorf("directory is not a union filesystem directory")
+	}
+
+	return parent.CreateDir(user, name, perm, mode)
+}
+
+func RemoveUnionFile(fs *fs.FS, f fs.FSNode) error {
+	parent, ok := f.Parent().(*UnionDir)
+	if !ok {
+		return fmt.Errorf("parent is not a union filesystem directory")
+	}
+
+	return parent.RemoveFile(f)
+}
+
+func NewUnionFS() *fs.FS {
+	return &fs.FS{
+		Root:       &UnionDir{baseUnionNode: baseUnionNode{path: "/"}},
+		CreateFile: CreateUnionFile,
+		CreateDir:  CreateUnionDir,
+		RemoveFile: RemoveUnionFile,
+	}
+}
+
+// Mount a 9p client into the filesystem
+func Mount(fs *fs.FS, c *client.Client, old string, option MountOption, create bool) error {
+	root, ok := fs.Root.(*UnionDir)
+	if !ok {
+		return fmt.Errorf("cannot mount into non-union filesystem.")
+	}
+
+	entry := mountEntry{
+		c:          c,
+		mountPoint: old,
+		replace:    option == REPLACE,
+		create:     create,
+	}
+
+	root.Lock()
+	defer root.Unlock()
+
+	if option == BEFORE || option == REPLACE {
+		root.mountTable = append([]mountEntry{entry}, root.mountTable...)
+	} else {
+		root.mountTable = append(root.mountTable, entry)
+	}
+
+	return nil
+}
+
+// Bind a part of the filesystem to another part
+func Bind(fs *fs.FS, path string, old string, option MountOption, create bool) error {
+	root, ok := fs.Root.(*UnionDir)
+	if !ok {
+		return fmt.Errorf("cannot bind into non-union filesystem")
+	}
+
+	// TODO handle mounting on files
+	pathdir := root.findDir(path)
+	if pathdir == nil {
+		return fmt.Errorf("cannot find path to bind")
+	}
+
+	entry := mountEntry{
+		d:          pathdir,
+		mountPoint: old,
+		replace:    option == REPLACE,
+		create:     create,
+	}
+
+	root.Lock()
+	defer root.Unlock()
+
+	if option == BEFORE || option == REPLACE {
+		root.mountTable = append([]mountEntry{entry}, root.mountTable...)
+	} else {
+		root.mountTable = append(root.mountTable, entry)
+	}
+
+	return nil
+}
+
+// Unmount everything that is mounted at the provided path.
+//
+// 9p clients that have been unmounted are returned.
+func UnmountPoint(fs *fs.FS, old string) ([]*client.Client, error) {
+	root, ok := fs.Root.(*UnionDir)
+	if !ok {
+		return []*client.Client{}, fmt.Errorf("cannot unmount in a non-union filesystem")
+	}
+
+	root.Lock()
+	defer root.Unlock()
+
+	clients := []*client.Client{}
+	mountTable := []mountEntry{}
+
+	for _, me := range root.mountTable {
+		if me.mountPoint != old {
+			mountTable = append(mountTable, me)
+		} else if me.c != nil {
+			clients = append(clients, me.c)
+		}
+	}
+
+	root.mountTable = mountTable
+
+	return clients, nil
+}
+
+// Unmount the client that was previously mounted at the provided path.
+func UnmountClient(fs *fs.FS, c *client.Client, old string) error {
+	root, ok := fs.Root.(*UnionDir)
+	if !ok {
+		return fmt.Errorf("cannot unmount in a non-union filesystem")
+	}
+
+	root.Lock()
+	defer root.Unlock()
+
+	mountTable := []mountEntry{}
+
+	for _, me := range root.mountTable {
+		if me.mountPoint != old || me.c != c {
+			mountTable = append(mountTable, me)
+		}
+	}
+
+	root.mountTable = mountTable
+
+	return nil
+}
+
+// Unmount the bind that was previously set at the provided path.
+func UnmountBind(fs *fs.FS, path string, old string) error {
+	root, ok := fs.Root.(*UnionDir)
+	if !ok {
+		return fmt.Errorf("cannot unmount in a non-union filesystem")
+	}
+
+	root.Lock()
+	defer root.Unlock()
+
+	mountTable := []mountEntry{}
+
+	for _, me := range root.mountTable {
+		// TODO handle file level binds
+		if me.mountPoint != old || me.d == nil || me.d.path != path {
+			mountTable = append(mountTable, me)
+		}
+	}
+
+	root.mountTable = mountTable
+
+	return nil
+}

--- a/union/union_test.go
+++ b/union/union_test.go
@@ -1,7 +1,9 @@
 package union
 
 import (
+	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/knusbaum/go9p"
@@ -10,157 +12,385 @@ import (
 	"github.com/knusbaum/go9p/proto"
 )
 
-type TwoPipe struct {
+type twoPipe struct {
 	*io.PipeReader
 	*io.PipeWriter
 }
 
-func (t *TwoPipe) Close() error {
+func (t *twoPipe) Close() error {
 	t.PipeReader.Close()
 	t.PipeWriter.Close()
 	return nil
 }
 
-func TestSingleRootMount(t *testing.T) {
-	ufs := NewUnionFS()
+func findDir(t *testing.T, ud fs.Dir, rel string) fs.Dir {
+	rel = strings.TrimPrefix(rel, "/")
 
-	rootfs, rootfsdir := fs.NewFS("glenda", "glenda", 0555)
-	bindir := fs.NewStaticDir(rootfs.NewStat("bin", "glenda", "glenda", 0555))
-	bindir.AddChild(fs.NewStaticFile(rootfs.NewStat("ls", "glenda", "glenda", 0444), []byte("Binary data\n")))
-	rootfsdir.AddChild(bindir)
-	p1r, p1w := io.Pipe()
-	p2r, p2w := io.Pipe()
-	go go9p.ServeReadWriter(p1r, p2w, rootfs.Server())
+	if rel == "" {
+		return ud
+	}
 
-	rootc, err := client.NewClient(&TwoPipe{p2r, p1w}, "glenda", "glenda")
+	parts := strings.Split(rel, "/")
+	d := ud
+	var n fs.Dir
+
+	for _, part := range parts {
+		if d == nil {
+			t.Fatalf("%s not found in %s", rel, ud)
+			return nil
+		}
+
+		children := d.Children()
+		child, ok := children[part]
+		if !ok {
+			t.Fatalf("%s not found in %s", rel, ud)
+			return nil
+		}
+
+		n, ok = child.(fs.Dir)
+		d = n
+		if !ok {
+			t.Fatalf("%s not found in %s", rel, ud)
+			return nil
+		}
+	}
+
+	return n
+}
+
+func findFile(t *testing.T, ud fs.Dir, rel string) fs.File {
+	rel = strings.TrimPrefix(rel, "/")
+
+	if rel == "" {
+		t.Fatalf("empty relative path")
+		return nil
+	}
+
+	parts := strings.Split(rel, "/")
+	d := ud
+	var n fs.FSNode
+
+	for _, part := range parts {
+		if d == nil {
+			t.Fatalf("%s not found in %s", rel, ud)
+			return nil
+		}
+
+		children := d.Children()
+		child, ok := children[part]
+		if !ok {
+			t.Fatalf("%s not found in %s", rel, ud)
+			return nil
+		}
+
+		n = child
+		if cd, ok := child.(fs.Dir); ok {
+			d = cd
+		}
+	}
+
+	if uf, ok := n.(fs.File); ok {
+		return uf
+	} else {
+		t.Fatalf("%s not found in %s", rel, ud)
+	}
+
+	t.Fatalf("%s not found in %s", rel, ud)
+	return nil
+}
+
+func mustNewClient(rwc io.ReadWriteCloser) *client.Client {
+	c, err := client.NewClient(rwc, "glenda", "glenda")
 	if err != nil {
-		t.Fatalf("%s", err)
+		panic(err)
 	}
 
-	err = Mount(ufs, rootc, "/", REPLACE, false)
+	return c
+}
+
+func mustMount(ufs *fs.FS, c *client.Client, old string, option MountOption, create bool) {
+	err := Mount(ufs, c, old, option, create)
 	if err != nil {
-		t.Fatalf("%s", err)
-	}
-
-	bin, ok := ufs.Root.Children()["bin"]
-	if !ok {
-		t.Fatalf("/bin not found")
-	}
-
-	ls, ok := bin.(fs.Dir).Children()["ls"]
-	if !ok {
-		t.Fatalf("/bin/ls not found")
-	}
-
-	lsf := ls.(fs.File)
-	lsf.Open(1234, proto.Oread)
-	lsc, err := lsf.Read(1234, 0, 1024)
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-
-	if string(lsc) != "Binary data\n" {
-		t.Fatalf("Contents of ls doesn't match: '%s' and '%s'", string(lsc), "Binary data\n")
+		panic(err)
 	}
 }
 
-func TestUnionBinMount(t *testing.T) {
-	ufs := NewUnionFS()
+func mustBind(ufs *fs.FS, path string, old string, option MountOption, create bool) {
+	err := Bind(ufs, path, old, option, create)
+	if err != nil {
+		panic(err)
+	}
+}
 
-	// This is the root ('/') with directories /bin (with ls) and /usr.
-	rootfs, rootfsdir := fs.NewFS("glenda", "glenda", 0555)
-	bindir := fs.NewStaticDir(rootfs.NewStat("bin", "glenda", "glenda", 0555))
-	bindir.AddChild(fs.NewStaticFile(rootfs.NewStat("ls", "glenda", "glenda", 0444), []byte("Binary data\n")))
-	rootfsdir.AddChild(bindir)
-	rootfsdir.AddChild(fs.NewStaticDir(rootfs.NewStat("usr", "glenda", "glenda", 0555)))
+func assertFile(parent fs.Dir, name string, contents string) {
+	children := parent.Children()
+
+	if f, ok := children[name]; !ok {
+		panic(fmt.Errorf("%s is not found in %s", name, parent))
+	} else {
+		ff := f.(fs.File)
+		err := ff.Open(1234, proto.Oread)
+		if err != nil {
+			panic(err)
+		}
+		defer ff.Close(1234)
+
+		fc, err := ff.Read(1234, 0, 1024)
+		if err != nil {
+			panic(fmt.Errorf("failure to read %s: %s", name, err))
+		}
+
+		if string(fc) != contents {
+			panic(fmt.Errorf("contents of %s doesn't match '%s': %s", name, contents, string(fc)))
+		}
+	}
+
+}
+
+func startServer(sfs *fs.FS) io.ReadWriteCloser {
 	p1r, p1w := io.Pipe()
 	p2r, p2w := io.Pipe()
-	rootpipe := &TwoPipe{p2r, p1w}
-	go go9p.ServeReadWriter(p1r, p2w, rootfs.Server())
+	pipe := &twoPipe{p2r, p1w}
+	go go9p.ServeReadWriter(p1r, p2w, sfs.Server())
+	return pipe
+}
+
+func newFS() (*fs.FS, *fs.StaticDir) {
+	return fs.NewFS("glenda", "glenda", 0755)
+}
+
+func newStaticDir(f *fs.FS, name string) *fs.StaticDir {
+	return fs.NewStaticDir(f.NewStat(name, "glenda", "glenda", 0555))
+}
+
+func newStaticFile(f *fs.FS, name string, content string) fs.File {
+	return fs.NewStaticFile(f.NewStat(name, "glenda", "glenda", 0444), []byte(content))
+}
+
+func TestSingleRootMount(t *testing.T) {
+	rootfs, rootfsdir := newFS()
+	bindir := newStaticDir(rootfs, "bin")
+	bindir.AddChild(newStaticFile(rootfs, "ls", "Binary data\n"))
+	rootfsdir.AddChild(bindir)
+	rootpipe := startServer(rootfs)
+	defer rootpipe.Close()
+
+	ufs := NewUnionFS()
+	rootc := mustNewClient(rootpipe)
+	mustMount(ufs, rootc, "/", REPLACE, false)
+
+	bin := findDir(t, ufs.Root, "bin")
+	assertFile(bin, "ls", "Binary data\n")
+
+	err := UnmountClient(ufs, rootc, "/")
+	if err != nil {
+		panic(err)
+	}
+
+	if len(ufs.Root.Children()) != 0 {
+		t.Fatalf("root has not be unmounted")
+	}
+}
+
+func TestReplace(t *testing.T) {
+	// This is the root ('/') with directories /bin (with ls) and /usr.
+	rootfs, rootfsdir := newFS()
+	bindir := newStaticDir(rootfs, "bin")
+	bindir.AddChild(newStaticFile(rootfs, "ls", "Binary data\n"))
+	rootfsdir.AddChild(bindir)
+	rootfsdir.AddChild(newStaticDir(rootfs, "usr")) // Mount-point for /usr fs
+	rootpipe := startServer(rootfs)
+	defer rootpipe.Close()
 
 	// This is a /usr filesystem
-	usrfs, usrfsdir := fs.NewFS("glenda", "glenda", 0555)
-	usrbindir := fs.NewStaticDir(usrfs.NewStat("bin", "glenda", "glenda", 0555))
-	usrbindir.AddChild(fs.NewStaticFile(usrfs.NewStat("cat", "glenda", "glenda", 0444), []byte("More binary data\n")))
+	usrfs, usrfsdir := newFS()
+	usrbindir := newStaticDir(usrfs, "bin")
+	usrbindir.AddChild(newStaticFile(usrfs, "cat", "More binary data\n"))
 	usrfsdir.AddChild(usrbindir)
-	p1r, p1w = io.Pipe()
-	p2r, p2w = io.Pipe()
-	usrpipe := &TwoPipe{p2r, p1w}
-	go go9p.ServeReadWriter(p1r, p2w, usrfs.Server())
+	usrpipe := startServer(usrfs)
+	defer usrpipe.Close()
+
+	ufs := NewUnionFS()
+
+	rootc := mustNewClient(rootpipe)
+	mustMount(ufs, rootc, "/", AFTER, false)
+	defer UnmountClient(ufs, rootc, "/")
+
+	usrc := mustNewClient(usrpipe)
+	mustMount(ufs, usrc, "/usr", AFTER, false)
+	defer UnmountClient(ufs, usrc, "/usr")
+
+	// Replace /bin with /usr/bin
+	mustBind(ufs, "/usr/bin", "/bin", REPLACE, false)
+	bin := findDir(t, ufs.Root, "/bin")
+	if len(bin.Children()) != 1 {
+		t.Fatalf("/bin hasn't been replaced with /usr/bin")
+	}
+	assertFile(bin, "cat", "More binary data\n")
+
+	// Shadow out the root with /bin, which still remembers its content from its mount table
+	mustBind(ufs, "/bin", "/", REPLACE, false)
+	if len(ufs.Root.Children()) != 1 {
+		t.Fatalf("/ hasn't been replaced with shadowed content")
+	}
+	findFile(t, ufs.Root, "cat")
+
+	// Undo the shadowing of the root
+	err := UnmountBind(ufs, "/bin", "/")
+	if err != nil {
+		panic(err)
+	}
+	if len(ufs.Root.Children()) != 2 {
+		t.Fatalf("/ hasn't been restored to its pre-shadowed content")
+	}
+
+	// Undo the replacement of /bin
+	err = UnmountBind(ufs, "/usr/bin", "/bin")
+	if err != nil {
+		panic(err)
+	}
+	bin = findDir(t, ufs.Root, "/bin")
+	findFile(t, bin, "ls")
+}
+
+func TestCreate(t *testing.T) {
+	// This is the root ('/') with directories /bin (with ls) and /usr.
+	rootfs, rootfsdir := newFS()
+	bindir := newStaticDir(rootfs, "bin")
+	bindir.AddChild(newStaticFile(rootfs, "ls", "Binary data\n"))
+	rootfsdir.AddChild(bindir)
+	rootpipe := startServer(rootfs)
+	defer rootpipe.Close()
+
+	// This is an overlay filesystem that permits the user to create
+	//  directories in their own storage.
+	overlayfs, _ := newFS()
+	overlayfs.CreateDir = fs.CreateStaticDir
+	overlaypipe := startServer(overlayfs)
+	defer overlaypipe.Close()
+
+	// This is a second overlay filesystem
+	topfs, _ := newFS()
+	topfs.CreateDir = fs.CreateStaticDir
+	toppipe := startServer(topfs)
+	defer toppipe.Close()
+
+	ufs := NewUnionFS()
+
+	// Mount / as read-only
+	rootc := mustNewClient(rootpipe)
+	mustMount(ufs, rootc, "/", BEFORE, false)
+	defer UnmountClient(ufs, rootc, "/")
+
+	_, err := ufs.CreateDir(ufs, ufs.Root, "glenda", "tmp", 0755, 0x80)
+	if err == nil {
+		t.Fatalf("permission was granted to create a directory on a read-only filesystem")
+	}
+
+	// Mount / using the overlay that permits creation of directories
+	overlayc := mustNewClient(overlaypipe)
+	mustMount(ufs, overlayc, "/", AFTER, true)
+	defer UnmountClient(ufs, overlayc, "/")
+
+	tmp, err := ufs.CreateDir(ufs, ufs.Root, "glenda", "tmp", 0755, 0x80)
+	if err != nil {
+		panic(err)
+	}
+
+	findDir(t, ufs.Root, "/tmp")
+	findDir(t, ufs.Root, "/bin")
+
+	_, err = ufs.CreateDir(ufs, tmp, "glenda", "glenda", 0555, 0x80)
+	if err != nil {
+		panic(err)
+	}
+
+	findDir(t, ufs.Root, "/tmp/glenda")
+
+	// Mount / using the top-most fs that permits creation of directories
+	topc := mustNewClient(toppipe)
+	mustMount(ufs, topc, "/", BEFORE, true)
+
+	_, err = ufs.CreateDir(ufs, ufs.Root, "glenda", "usr", 0755, 0x80)
+	if err != nil {
+		panic(err)
+	}
+
+	findDir(t, ufs.Root, "/usr")
+
+	// Make sure that the /usr directory disappeared along with the
+	//  top-level filesystem where it was created.
+	UnmountClient(ufs, topc, "/")
+	if _, ok := ufs.Root.Children()["usr"]; ok {
+		t.Fatalf("usr was created in the wrong client")
+	}
+}
+
+func TestUnionMountBin(t *testing.T) {
+	// This is the root ('/') with directories /bin (with ls) and /usr.
+	rootfs, rootfsdir := newFS()
+	bindir := newStaticDir(rootfs, "bin")
+	bindir.AddChild(newStaticFile(rootfs, "ls", "Binary data\n"))
+	rootfsdir.AddChild(bindir)
+	rootfsdir.AddChild(newStaticDir(rootfs, "usr")) // Mount-point for /usr fs
+	rootpipe := startServer(rootfs)
+	defer rootpipe.Close()
+
+	// This is a /usr filesystem
+	usrfs, usrfsdir := newFS()
+	usrbindir := newStaticDir(usrfs, "bin")
+	usrbindir.AddChild(newStaticFile(usrfs, "cat", "More binary data\n"))
+	usrfsdir.AddChild(usrbindir)
+	usrpipe := startServer(usrfs)
+	defer usrpipe.Close()
+
+	// Create a union filesystem
+	ufs := NewUnionFS()
 
 	// Mount /
-	rootc, err := client.NewClient(rootpipe, "glenda", "glenda")
-	if err != nil {
-		t.Fatalf("error connecting to /:%s", err)
-	}
-	err = Mount(ufs, rootc, "/", REPLACE, false)
-	if err != nil {
-		t.Fatalf("error mounting /: %s", err)
-	}
+	rootc := mustNewClient(rootpipe)
+	mustMount(ufs, rootc, "/", REPLACE, false)
+	defer UnmountClient(ufs, rootc, "/")
 
 	// Mount /usr
-	usrc, err := client.NewClient(usrpipe, "glenda", "glenda")
-	if err != nil {
-		t.Fatalf("error connecting to /usr: %s", err)
-	}
-	err = Mount(ufs, usrc, "/usr", REPLACE, false)
-	if err != nil {
-		t.Fatalf("error mounting /usr: %s", err)
-	}
+	usrc := mustNewClient(usrpipe)
+	mustMount(ufs, usrc, "/usr", REPLACE, false)
 
-	usrbin := ufs.Root.(*UnionDir).findDir("/usr/bin")
-	if usrbin == nil {
-		t.Fatalf("/usr/bin not found")
-	}
-
-	cat := usrbin.findFile("cat")
-	if cat == nil {
-		t.Fatalf("/usr/bin/cat not found")
-	}
+	// Check that /usr/bin is there and has cat from the mount
+	usrbin := findDir(t, ufs.Root, "/usr/bin")
+	findFile(t, usrbin, "cat")
 
 	// Bind /usr/bin to /bin
-	err = Bind(ufs, "/usr/bin", "/bin", AFTER, false)
+	mustBind(ufs, "/usr/bin", "/bin", AFTER, false)
+
+	// Verify that the union of all bins can be found in /bin
+	bin := findDir(t, ufs.Root, "/bin")
+	if len(bin.Children()) != 2 {
+		t.Fatalf("/bin doesn't have the union of /bin and /usr/bin: %s", bin)
+	}
+	assertFile(bin, "ls", "Binary data\n")
+	assertFile(bin, "cat", "More binary data\n")
+
+	// Un-bind /usr/bin from /bin
+	err := UnmountBind(ufs, "/usr/bin", "/bin")
 	if err != nil {
-		t.Fatalf("error binding /usr/bin to /bin: %s", err)
+		panic(err)
 	}
 
-	bin := ufs.Root.(*UnionDir).findDir("/bin")
-	if bin == nil {
-		t.Fatalf("/bin not found")
+	bin = findDir(t, ufs.Root, "/bin")
+	if len(bin.Children()) != 1 {
+		t.Fatalf("/usr/bin hasn't been unbound from /bin: %s", bin)
+	}
+	assertFile(bin, "ls", "Binary data\n")
+
+	// Un-mount /usr
+	err = UnmountClient(ufs, usrc, "/usr")
+	if err != nil {
+		panic(err)
 	}
 
-	binchild := bin.Children()
-	if len(binchild) != 2 {
-		t.Fatalf("/bin doesn't have the union of /bin and /usr/bin: %v mount table: %+v", bin.Children(), bin.mountTable)
-	}
-
-	if ls, ok := binchild["ls"]; !ok {
-		t.Fatalf("ls is not found in /bin")
-	} else {
-		lsf := ls.(*UnionFile)
-		lsf.Open(1234, proto.Oread)
-		lsc, err := lsf.Read(1234, 0, 1024)
-		if err != nil {
-			t.Fatalf("Failure to read ls: %s", err)
-		}
-
-		if string(lsc) != "Binary data\n" {
-			t.Fatalf("Contents of ls doesn't match 'Binary data\n': %s", string(lsc))
-		}
-	}
-
-	if cat, ok := binchild["cat"]; !ok {
-		t.Fatalf("cat is not found in /bin")
-	} else {
-		catf := cat.(*UnionFile)
-		catf.Open(2345, proto.Oread)
-		catc, err := catf.Read(2345, 0, 1024)
-		if err != nil {
-			t.Fatalf("Failure to read cat: %s", err)
-		}
-
-		if string(catc) != "More binary data\n" {
-			t.Fatalf("Contents of cat doesn't match 'More binary data\n': %s", string(catc))
-		}
+	usr := findDir(t, ufs.Root, "/usr")
+	if len(usr.Children()) != 0 {
+		t.Fatalf("/usr hasn't been unmounted")
 	}
 }

--- a/union/union_test.go
+++ b/union/union_test.go
@@ -1,0 +1,166 @@
+package union
+
+import (
+	"io"
+	"testing"
+
+	"github.com/knusbaum/go9p"
+	"github.com/knusbaum/go9p/client"
+	"github.com/knusbaum/go9p/fs"
+	"github.com/knusbaum/go9p/proto"
+)
+
+type TwoPipe struct {
+	*io.PipeReader
+	*io.PipeWriter
+}
+
+func (t *TwoPipe) Close() error {
+	t.PipeReader.Close()
+	t.PipeWriter.Close()
+	return nil
+}
+
+func TestSingleRootMount(t *testing.T) {
+	ufs := NewUnionFS()
+
+	rootfs, rootfsdir := fs.NewFS("glenda", "glenda", 0555)
+	bindir := fs.NewStaticDir(rootfs.NewStat("bin", "glenda", "glenda", 0555))
+	bindir.AddChild(fs.NewStaticFile(rootfs.NewStat("ls", "glenda", "glenda", 0444), []byte("Binary data\n")))
+	rootfsdir.AddChild(bindir)
+	p1r, p1w := io.Pipe()
+	p2r, p2w := io.Pipe()
+	go go9p.ServeReadWriter(p1r, p2w, rootfs.Server())
+
+	rootc, err := client.NewClient(&TwoPipe{p2r, p1w}, "glenda", "glenda")
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	err = Mount(ufs, rootc, "/", REPLACE, false)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	bin, ok := ufs.Root.Children()["bin"]
+	if !ok {
+		t.Fatalf("/bin not found")
+	}
+
+	ls, ok := bin.(fs.Dir).Children()["ls"]
+	if !ok {
+		t.Fatalf("/bin/ls not found")
+	}
+
+	lsf := ls.(fs.File)
+	lsf.Open(1234, proto.Oread)
+	lsc, err := lsf.Read(1234, 0, 1024)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	if string(lsc) != "Binary data\n" {
+		t.Fatalf("Contents of ls doesn't match: '%s' and '%s'", string(lsc), "Binary data\n")
+	}
+}
+
+func TestUnionBinMount(t *testing.T) {
+	ufs := NewUnionFS()
+
+	// This is the root ('/') with directories /bin (with ls) and /usr.
+	rootfs, rootfsdir := fs.NewFS("glenda", "glenda", 0555)
+	bindir := fs.NewStaticDir(rootfs.NewStat("bin", "glenda", "glenda", 0555))
+	bindir.AddChild(fs.NewStaticFile(rootfs.NewStat("ls", "glenda", "glenda", 0444), []byte("Binary data\n")))
+	rootfsdir.AddChild(bindir)
+	rootfsdir.AddChild(fs.NewStaticDir(rootfs.NewStat("usr", "glenda", "glenda", 0555)))
+	p1r, p1w := io.Pipe()
+	p2r, p2w := io.Pipe()
+	rootpipe := &TwoPipe{p2r, p1w}
+	go go9p.ServeReadWriter(p1r, p2w, rootfs.Server())
+
+	// This is a /usr filesystem
+	usrfs, usrfsdir := fs.NewFS("glenda", "glenda", 0555)
+	usrbindir := fs.NewStaticDir(usrfs.NewStat("bin", "glenda", "glenda", 0555))
+	usrbindir.AddChild(fs.NewStaticFile(usrfs.NewStat("cat", "glenda", "glenda", 0444), []byte("More binary data\n")))
+	usrfsdir.AddChild(usrbindir)
+	p1r, p1w = io.Pipe()
+	p2r, p2w = io.Pipe()
+	usrpipe := &TwoPipe{p2r, p1w}
+	go go9p.ServeReadWriter(p1r, p2w, usrfs.Server())
+
+	// Mount /
+	rootc, err := client.NewClient(rootpipe, "glenda", "glenda")
+	if err != nil {
+		t.Fatalf("error connecting to /:%s", err)
+	}
+	err = Mount(ufs, rootc, "/", REPLACE, false)
+	if err != nil {
+		t.Fatalf("error mounting /: %s", err)
+	}
+
+	// Mount /usr
+	usrc, err := client.NewClient(usrpipe, "glenda", "glenda")
+	if err != nil {
+		t.Fatalf("error connecting to /usr: %s", err)
+	}
+	err = Mount(ufs, usrc, "/usr", REPLACE, false)
+	if err != nil {
+		t.Fatalf("error mounting /usr: %s", err)
+	}
+
+	usrbin := ufs.Root.(*UnionDir).findDir("/usr/bin")
+	if usrbin == nil {
+		t.Fatalf("/usr/bin not found")
+	}
+
+	cat := usrbin.findFile("cat")
+	if cat == nil {
+		t.Fatalf("/usr/bin/cat not found")
+	}
+
+	// Bind /usr/bin to /bin
+	err = Bind(ufs, "/usr/bin", "/bin", AFTER, false)
+	if err != nil {
+		t.Fatalf("error binding /usr/bin to /bin: %s", err)
+	}
+
+	bin := ufs.Root.(*UnionDir).findDir("/bin")
+	if bin == nil {
+		t.Fatalf("/bin not found")
+	}
+
+	binchild := bin.Children()
+	if len(binchild) != 2 {
+		t.Fatalf("/bin doesn't have the union of /bin and /usr/bin: %v mount table: %+v", bin.Children(), bin.mountTable)
+	}
+
+	if ls, ok := binchild["ls"]; !ok {
+		t.Fatalf("ls is not found in /bin")
+	} else {
+		lsf := ls.(*UnionFile)
+		lsf.Open(1234, proto.Oread)
+		lsc, err := lsf.Read(1234, 0, 1024)
+		if err != nil {
+			t.Fatalf("Failure to read ls: %s", err)
+		}
+
+		if string(lsc) != "Binary data\n" {
+			t.Fatalf("Contents of ls doesn't match 'Binary data\n': %s", string(lsc))
+		}
+	}
+
+	if cat, ok := binchild["cat"]; !ok {
+		t.Fatalf("cat is not found in /bin")
+	} else {
+		catf := cat.(*UnionFile)
+		catf.Open(2345, proto.Oread)
+		catc, err := catf.Read(2345, 0, 1024)
+		if err != nil {
+			t.Fatalf("Failure to read cat: %s", err)
+		}
+
+		if string(catc) != "More binary data\n" {
+			t.Fatalf("Contents of cat doesn't match 'More binary data\n': %s", string(catc))
+		}
+	}
+}


### PR DESCRIPTION
I've written an experimental proof of concept union filesystem for go9p inspired by plan9 with mount and bind operations. Before I get too far with this I'm hoping to get feedback on the approach, design, and API's. I think it could also be an interesting addition to the go9p package for systems that want to be able to support a plan9-style union filesystem composed of go9p clients.

Thank you for the really good go9p implementation that made this so much easier.